### PR TITLE
progress

### DIFF
--- a/apps/frontend/Localer/src/components/TheNavigation.vue
+++ b/apps/frontend/Localer/src/components/TheNavigation.vue
@@ -33,7 +33,7 @@ const liClasses = (key: string) =>
         return
       }
     })
-    if (translate.getNumberOfLanguagesTranslated(key) === user.languages.length) {
+    if (translate.getNumberOfLanguagesTranslated(key) === user.languages.length && user.languages.length > 0) {
       classes['bg-gradient-to-r from-orange-100 to-transparent text-orange-500'] = true
     }
 
@@ -143,7 +143,7 @@ const toggleEditing = () => {
               text="sm"
               class="whitespace-nowrap"
               :class="
-                translate.getNumberOfLanguagesTranslated(key) === user.languages.length
+                translate.getNumberOfLanguagesTranslated(key) === user.languages.length && user.languages.length > 0
                   ? 'text-orange-500'
                   : 'text-brown-500'
               "

--- a/apps/frontend/Localer/src/stores/translationStore.ts
+++ b/apps/frontend/Localer/src/stores/translationStore.ts
@@ -56,14 +56,38 @@ export const useTranslationStore = defineStore({
     async loadTranslations() {
       const user = useUserStore()
       const username = user.username.replace(/ /g, '-')
-      this.locales.forEach(async (locale) => {
+      user.languages.forEach(async (locale) => {
         const contentRequest = await getContent(username, locale)
         if (contentRequest.response) {
           this.translations[locale] = JSON.parse(Base64.decode(contentRequest.response.content))
           this.initialTranslations[locale] = JSON.parse(
             Base64.decode(contentRequest.response.content)
           )
+          this.initialKeys.forEach((key) => {
+            if (!this.translations[locale][key]) {
+              this.translations[locale][key] = ''
+              this.initialTranslations[locale][key] = ''
+            }
+          })
         }
+        // add any missing locale to this.locales
+        if (!this.locales.includes(locale)) {
+          this.locales.push(locale)
+          this.initialLocales.push(locale)
+        }
+        // add any missing keys to this.keys
+        Object.keys(this.translations[locale]).forEach((key) => {
+          if (!this.keys.includes(key)) {
+            this.keys.push(key)
+            this.initialKeys.push(key)
+            this.locales.forEach((locale) => {
+              if (this.translations[locale][key] === undefined) {
+                this.translations[locale][key] = ''
+                this.initialTranslations[locale][key] = ''
+              }
+            })
+          }
+        })
       })
     },
     checkKey(key: string) {

--- a/apps/frontend/Localer/vite.config.ts
+++ b/apps/frontend/Localer/vite.config.ts
@@ -34,6 +34,9 @@ export default () => {
       alias: {
         '@': fileURLToPath(new URL('./src', import.meta.url))
       }
+    },
+    define: {
+      __VUE_PROD_DEVTOOLS__: true
     }
   })
 }

--- a/locales/en_US.json
+++ b/locales/en_US.json
@@ -1,4 +1,5 @@
 {
+  "EnglishLanguageName": "English",
   "cookbookBadgeName": "An Entire Cookbook Worth Of Recipes",
   "cookbookBadgeDesc": "Create at least 100 recipes.",
   "explorerBadgeName": "Lost In The Kitchen",

--- a/locales/hu_HU.json
+++ b/locales/hu_HU.json
@@ -1,4 +1,5 @@
 {
+  "EnglishLanguageName": "Hungarian",
   "hoarderBadgeName": "Recept Halmozó",
   "hoarderBadgeDesc": "Ments el legalább 100 receptet.",
   "HomeNav": "Főoldal"

--- a/locales/ko_KR.json
+++ b/locales/ko_KR.json
@@ -1,4 +1,5 @@
 {
+  "EnglishLanguageName": "Korean",
   "hoarderBadgeName": "레시피 수집광",
   "hoarderBadgeDesc": "최소 100개 레시피를 저장해주세요.",
   "HomeNav": "홈"


### PR DESCRIPTION
### Description
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3f71715</samp>

This pull request enhances the functionality, performance, and user experience of the Localer app, which allows users to translate and save files on GitHub. It improves the logic and efficiency of importing and exporting translations, using the user's selected languages, and creating or updating files and pull requests on GitHub. It also adds the `EnglishLanguageName` key to the locale files and enables the Vue devtools extension in production mode.

### Changes
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3f71715</samp>

*  Renamed `createFilesAndCommit` to `createFileAndCommit` and simplified its logic to create or update one file at a time on GitHub ([link](https://github.com/14A-A-Lyedlik-Devs/Gump/pull/334/files?diff=unified&w=0#diff-11052d7ab54deb172a2bcaead44db14f418e048fd0d50b6e2d4316787a681881L6-R6), [link](https://github.com/14A-A-Lyedlik-Devs/Gump/pull/334/files?diff=unified&w=0#diff-16e94393c866242711ce3fe49b92b528027059dc3a14542cc668b00409a611e6L237-R271), [link](https://github.com/14A-A-Lyedlik-Devs/Gump/pull/334/files?diff=unified&w=0#diff-16e94393c866242711ce3fe49b92b528027059dc3a14542cc668b00409a611e6L284-L285))
*  Imported and called `loadTranslations` from `useTranslationStore` to load the user's translations from GitHub in the `App.vue` component ([link](https://github.com/14A-A-Lyedlik-Devs/Gump/pull/334/files?diff=unified&w=0#diff-11052d7ab54deb172a2bcaead44db14f418e048fd0d50b6e2d4316787a681881L15-R17), [link](https://github.com/14A-A-Lyedlik-Devs/Gump/pull/334/files?diff=unified&w=0#diff-11052d7ab54deb172a2bcaead44db14f418e048fd0d50b6e2d4316787a681881L50-R65), [link](https://github.com/14A-A-Lyedlik-Devs/Gump/pull/334/files?diff=unified&w=0#diff-d4e3461bdfd2d3947c9dbf28dc812edde8dca9c0d28aac9937955ea5f2a94091L59-R59))
*  Modified `saveChanges` in the `App.vue` component to use the `languages` property from the `user` store, filter out empty translations, and call `createFileAndCommit` for each content item in a `forEach` loop ([link](https://github.com/14A-A-Lyedlik-Devs/Gump/pull/334/files?diff=unified&w=0#diff-11052d7ab54deb172a2bcaead44db14f418e048fd0d50b6e2d4316787a681881L22-R45), [link](https://github.com/14A-A-Lyedlik-Devs/Gump/pull/334/files?diff=unified&w=0#diff-16e94393c866242711ce3fe49b92b528027059dc3a14542cc668b00409a611e6L333-L343))
*  Changed the condition for applying the orange color to the navigation items and language labels in the `TheNavigation.vue` component to check if the user has any languages selected ([link](https://github.com/14A-A-Lyedlik-Devs/Gump/pull/334/files?diff=unified&w=0#diff-9890f2778caeb8a367af042738d5fe21824082f53358a37d3e1597f6ef5d6960L36-R36), [link](https://github.com/14A-A-Lyedlik-Devs/Gump/pull/334/files?diff=unified&w=0#diff-9890f2778caeb8a367af042738d5fe21824082f53358a37d3e1597f6ef5d6960L146-R146))
*  Added missing locale and key handling to the `useTranslationStore` module, to ensure that the translation interface has all the locales and keys that the user has translated or can translate, and that the initial state of the translations is preserved ([link](https://github.com/14A-A-Lyedlik-Devs/Gump/pull/334/files?diff=unified&w=0#diff-d4e3461bdfd2d3947c9dbf28dc812edde8dca9c0d28aac9937955ea5f2a94091L66-R90))
*  Enabled the Vue devtools extension in production mode by defining and setting the `__VUE_PROD_DEVTOOLS__` global variable in the `vite.config.ts` file ([link](https://github.com/14A-A-Lyedlik-Devs/Gump/pull/334/files?diff=unified&w=0#diff-332ae650410446bf78575b97c5b97ead4ec66347a3d4ece851e9d6b3d63ea780R37-R39))
*  Added the `EnglishLanguageName` key and value to the `locales/en_US.json`, `locales/hu_HU.json`, and `locales/ko_KR.json` files, to provide the English name of the language for display purposes ([link](https://github.com/14A-A-Lyedlik-Devs/Gump/pull/334/files?diff=unified&w=0#diff-4082c608a443cbcd30ab810bf0e9ab801b08c94fc8c3017ca4287456f204e961R2), [link](https://github.com/14A-A-Lyedlik-Devs/Gump/pull/334/files?diff=unified&w=0#diff-2982c6f8d2bfc747a25c0058141f03e10facf0f4e4f913b50cf361454f609471R2), [link](https://github.com/14A-A-Lyedlik-Devs/Gump/pull/334/files?diff=unified&w=0#diff-d51ba46f0b3c186c9781659ad4c33a7592229f21c2f7403bd39a197d7ca28110R2))

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 3f71715</samp>

> _We're sailing on the `vite` ship with the `Vue` devtools on_
> _We've added `EnglishLanguageName` to every locale we've done_
> _We've optimized the `octokit` and the `useTranslationStore`_
> _So heave away, me hearties, and let's code some more_
