### PR TITLE
Firefox good

### DIFF
--- a/apps/frontend/Localer/src/components/MainContent.vue
+++ b/apps/frontend/Localer/src/components/MainContent.vue
@@ -160,6 +160,7 @@ const colorSpecialCharacters = (text: string) => {
         resize="none"
         overflow="hidden"
         :html="colorSpecialCharacters(translations[locale][selectedKey])"
+        style="white-space: -moz-pre-space"
         @input="inputFunc(locale)"
         @keydown.enter.prevent
       />


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at f8960be</samp>

### Summary
🐛🎨🦊

<!--
1.  🐛 - This emoji represents a bug fix, as the change is intended to resolve a bug that affects the user experience and functionality of the feature.
2.  🎨 - This emoji represents a style improvement, as the change modifies the appearance of the component to match the user input and expectations.
3.  🦊 - This emoji represents a browser-specific fix, as the change is only applied to Firefox browsers and not other browsers. This emoji is also a pun on the Firefox logo, which features a fox.
-->
Added a CSS fix for Firefox to preserve leading spaces in `v-textarea` input. This is part of a feature for creating and editing custom templates in `MainContent.vue`.

> _`v-textarea` styled_
> _Firefox preserves spaces_
> _Winter templates fixed_

### Walkthrough
*  Add a CSS style to preserve leading spaces in user input for Firefox browsers ([link](https://github.com/14A-A-Lyedlik-Devs/Gump/pull/390/files?diff=unified&w=0#diff-73a786761816d8da500abf91956a46e406881bab621a2a87357998368e45cdf0R163))


