### PR TITLE
TextInput.vue listening on port 6969...

### DIFF
--- a/apps/frontend/Gump/components/TextInput.vue
+++ b/apps/frontend/Gump/components/TextInput.vue
@@ -1,0 +1,24 @@
+<script setup lang="ts">
+defineProps<{
+  text: string
+  type?: 'email' | 'password'
+}>()
+
+defineEmits<{
+  (event: 'update:text', ...args: any[]): void
+}>()
+</script>
+
+<template>
+  <input
+    :value="text"
+    :type="type || 'text'"
+    h-min-12
+    border-0 rounded-full bg-transparent p-3 shadow-inner
+    @input="$emit('update:text', ($event.target as HTMLInputElement).value)"
+  >
+</template>
+
+<style scoped>
+
+</style>

--- a/apps/frontend/Gump/pages/home.vue
+++ b/apps/frontend/Gump/pages/home.vue
@@ -1,7 +1,9 @@
 <script setup lang="ts">
+import { useRecipeStore } from '~/stores/recipe'
 import { useUserStore } from '~/stores/user'
 
 const user = useUserStore()
+const recipe = useRecipeStore()
 </script>
 
 <template>
@@ -16,6 +18,7 @@ const user = useUserStore()
       <div mt-5 class="crimsonBtn">
         <div class="i-fa6-solid-box-tissue" />
       </div>
+      <TextInput v-model:text="recipe.recipe.title" />
     </div>
     <MainButton mb-2 self-center color="orange" icon-type="create" title="Create recipe" />
     <TheNavbar />

--- a/apps/frontend/Gump/stores/recipe.ts
+++ b/apps/frontend/Gump/stores/recipe.ts
@@ -1,11 +1,11 @@
-export interface Ingredient {
+export interface IIngredient {
   name: string
   value: number
   volume: string
   linkedRecipe: number
 }
 
-export interface Recipe {
+export interface IRecipe {
   id: number
   title: string
   author: number
@@ -14,7 +14,7 @@ export interface Recipe {
   serves: number
   categories: number[]
   tags: string[]
-  ingredients: Ingredient[]
+  ingredients: IIngredient[]
   steps: string[]
   viewCount: number
   saveCount: number
@@ -29,7 +29,7 @@ export interface Recipe {
 }
 
 interface IRecipeState {
-  recipe: Recipe
+  recipe: IRecipe
 }
 
 export const useRecipeStore = defineStore('recipe', () => {

--- a/apps/frontend/Gump/stores/recipe.ts
+++ b/apps/frontend/Gump/stores/recipe.ts
@@ -1,0 +1,74 @@
+export interface Ingredient {
+  name: string
+  value: number
+  volume: string
+  linkedRecipe: number
+}
+
+export interface Recipe {
+  id: number
+  title: string
+  author: number
+  image: number
+  language: string
+  serves: number
+  categories: number[]
+  tags: string[]
+  ingredients: Ingredient[]
+  steps: string[]
+  viewCount: number
+  saveCount: number
+  isLiked: boolean
+  likeCount: number
+  referenceCount: number
+  isArchived: boolean
+  isOriginal: boolean
+  originalRecipe: number
+  isPrivate: boolean
+  forks: number[]
+}
+
+interface IRecipeState {
+  recipe: Recipe
+}
+
+export const useRecipeStore = defineStore('recipe', () => {
+  // state
+  const state = reactive<IRecipeState>({
+    recipe: {
+      id: 0,
+      title: '',
+      author: 0,
+      image: 0,
+      language: '',
+      serves: 0,
+      categories: [],
+      tags: [],
+      ingredients: [],
+      steps: [],
+      viewCount: 0,
+      saveCount: 0,
+      isLiked: false,
+      likeCount: 0,
+      referenceCount: 0,
+      isArchived: false,
+      isOriginal: false,
+      originalRecipe: 0,
+      isPrivate: false,
+      forks: [],
+    },
+  })
+
+  // getters
+  // ...
+
+  // actions
+  // ...
+
+  return {
+    ...toRefs(state),
+  }
+},
+{
+  persist: true,
+})

--- a/apps/frontend/Gump/tests/MainButton.nuxt.test.ts
+++ b/apps/frontend/Gump/tests/MainButton.nuxt.test.ts
@@ -36,7 +36,6 @@ describe('MainButton', () => {
         color: 'orange',
       },
     })
-    // expect(wrapper.classes()).toContain('orangeGradient'
     expect(wrapper.find('.orangeGradient').exists()).toBe(true)
   })
 })

--- a/apps/frontend/Gump/tests/TextInput.nuxt.test.ts
+++ b/apps/frontend/Gump/tests/TextInput.nuxt.test.ts
@@ -1,0 +1,33 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { mount } from '@vue/test-utils'
+import TextInput from '~/components/TextInput.vue'
+
+describe('TextInput', () => {
+  let wrapper: any
+
+  beforeEach(() => {
+    wrapper = mount(TextInput, {
+      props: {
+        text: 'Hello',
+        type: 'email',
+      },
+    })
+  })
+
+  it('should render the text prop', () => {
+    const input = wrapper.find('input')
+    expect(input.element.value).toBe('Hello')
+  })
+
+  it('should render the type prop', () => {
+    const input = wrapper.find('input')
+    expect(input.element.type).toBe('email')
+  })
+
+  it('should emit update:text event when input changes', async () => {
+    const input = wrapper.find('input')
+    await input.setValue('World')
+    expect(wrapper.emitted()).toHaveProperty('update:text')
+    expect(wrapper.emitted('update:text')[0][0]).toBe('World')
+  })
+})


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 0ac7225</samp>

### Summary
🆕🗃️✏️

<!--
1.  🆕 for adding a new component
2.  🗃️ for adding a new store module
3.  ✏️ for adding a feature to edit the recipe title
-->
This pull request adds a new feature, component, and store module to the frontend of Gump, a recipe app. The feature allows the user to edit the recipe title on the home page, using the `TextInput.vue` component and the `useRecipeStore` function. The component and the store module use Vue 3 and `pinia` features to simplify the code and enable local storage.

> _`useRecipeStore`_
> _Edit the title on the home_
> _Autumn leaves persist_

### Walkthrough
*  Add a new component `TextInput.vue` that defines a reusable input element ([link](https://github.com/14A-A-Lyedlik-Devs/Gump/pull/476/files?diff=unified&w=0#diff-f27ac0c81b09bcfe76ec0c371d9a57201909520bd0e75cca10195b28997e52d9R1-R24))
*  Import the `useRecipeStore` function from the `recipe.ts` store module in the `home.vue` page component ([link](https://github.com/14A-A-Lyedlik-Devs/Gump/pull/476/files?diff=unified&w=0#diff-d7c7cba00436b50ec11b988659397e360494f56d2f53f7b17812723e4b13ec8bL2-R6))
*  Add a `TextInput` component to the `home.vue` page template, and bind its text prop to the recipe title ([link](https://github.com/14A-A-Lyedlik-Devs/Gump/pull/476/files?diff=unified&w=0#diff-d7c7cba00436b50ec11b988659397e360494f56d2f53f7b17812723e4b13ec8bR21))
*  Add a new store module `recipe.ts` that defines the interfaces and logic for the recipe data ([link](https://github.com/14A-A-Lyedlik-Devs/Gump/pull/476/files?diff=unified&w=0#diff-fff9d1299723af9e15255bb8947c21b5d5453a9ef83d63926b63ae8b8f456b2eR1-R74))


