### PR TITLE
454 createsubheader

### DIFF
--- a/apps/frontend/Gump/assets/ModeDesign.svg
+++ b/apps/frontend/Gump/assets/ModeDesign.svg
@@ -1,0 +1,17 @@
+<svg width="140" height="46" viewBox="0 0 140 46" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g filter="url(#filter0_i_52045_6504)">
+<path d="M0 20.5C0 9.4543 8.95431 0.5 20 0.5H140L122 45.5H20C8.9543 45.5 0 36.5457 0 25.5V20.5Z" fill="#FFF3F6"/>
+</g>
+<defs>
+<filter id="filter0_i_52045_6504" x="0" y="0.5" width="140" height="47" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="2"/>
+<feGaussianBlur stdDeviation="6"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0.952941 0 0 0 0 0.345098 0 0 0 0 0.152941 0 0 0 0.4 0"/>
+<feBlend mode="normal" in2="shape" result="effect1_innerShadow_52045_6504"/>
+</filter>
+</defs>
+</svg>

--- a/apps/frontend/Gump/assets/ModeDesignActive.svg
+++ b/apps/frontend/Gump/assets/ModeDesignActive.svg
@@ -1,0 +1,16 @@
+<svg width="152" height="58" viewBox="0 0 152 58" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g filter="url(#filter0_d_52044_6495)">
+<path d="M6 24.5C6 13.4543 14.9543 4.5 26 4.5H146L128 49.5H26C14.9543 49.5 6 40.5457 6 29.5V24.5Z" fill="#F35827"/>
+</g>
+<defs>
+<filter id="filter0_d_52044_6495" x="0" y="0.5" width="152" height="57" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="2"/>
+<feGaussianBlur stdDeviation="3"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0.952941 0 0 0 0 0.345098 0 0 0 0 0.152941 0 0 0 0.4 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_52044_6495"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_52044_6495" result="shape"/>
+</filter>
+</defs>
+</svg>

--- a/apps/frontend/Gump/assets/ModeRaw.svg
+++ b/apps/frontend/Gump/assets/ModeRaw.svg
@@ -1,0 +1,17 @@
+<svg width="140" height="46" viewBox="0 0 140 46" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g filter="url(#filter0_i_52044_6494)">
+<path d="M18 0.5H120C131.046 0.5 140 9.45431 140 20.5V25.5C140 36.5457 131.046 45.5 120 45.5H0L18 0.5Z" fill="#FFF3F6"/>
+</g>
+<defs>
+<filter id="filter0_i_52044_6494" x="0" y="0.5" width="140" height="47" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="2"/>
+<feGaussianBlur stdDeviation="6"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0.952941 0 0 0 0 0.345098 0 0 0 0 0.152941 0 0 0 0.4 0"/>
+<feBlend mode="normal" in2="shape" result="effect1_innerShadow_52044_6494"/>
+</filter>
+</defs>
+</svg>

--- a/apps/frontend/Gump/assets/ModeRawActive.svg
+++ b/apps/frontend/Gump/assets/ModeRawActive.svg
@@ -1,0 +1,16 @@
+<svg width="152" height="58" viewBox="0 0 152 58" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g filter="url(#filter0_d_52045_6503)">
+<path d="M24 4.5H126C137.046 4.5 146 13.4543 146 24.5V29.5C146 40.5457 137.046 49.5 126 49.5H6L24 4.5Z" fill="#F35827"/>
+</g>
+<defs>
+<filter id="filter0_d_52045_6503" x="0" y="0.5" width="152" height="57" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="2"/>
+<feGaussianBlur stdDeviation="3"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0.952941 0 0 0 0 0.345098 0 0 0 0 0.152941 0 0 0 0.4 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_52045_6503"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_52045_6503" result="shape"/>
+</filter>
+</defs>
+</svg>

--- a/apps/frontend/Gump/assets/main.css
+++ b/apps/frontend/Gump/assets/main.css
@@ -1,0 +1,3 @@
+input {
+  background-color: transparent !important;
+}

--- a/apps/frontend/Gump/components/CreateSubHeader.vue
+++ b/apps/frontend/Gump/components/CreateSubHeader.vue
@@ -1,0 +1,105 @@
+<script setup lang="ts">
+import { useRecipeStore } from '~/stores/recipe'
+
+defineProps<{
+  variant: 'ingredients' | 'steps'
+}>()
+
+const recipe = useRecipeStore()
+
+const toggled = ref(false)
+
+function togglePanel() {
+  toggled.value = !toggled.value
+}
+
+recipe.mode = 'design'
+
+function toggleMode() {
+  recipe.mode = recipe.mode === 'raw' ? 'design' : 'raw'
+}
+</script>
+
+<template>
+  <div
+    flex="~ row" h-14 w-full items-center justify-between px-10 font-bold
+  >
+    <p v-if="!toggled" flex-1 text-center text-xl>
+      {{ variant === 'ingredients' ? $t('CreateIngredients') : $t('CreateSteps') }}
+    </p>
+    <div
+      v-else-if="variant === 'steps'"
+      flex-1 text-center text-lg
+    >
+      {{ $t('CreateStepsTip') }}
+
+      <!-- this should work but no -->
+      <!-- <i18n path="CreateStepsTip" tag="p">
+        <template #color>
+          <span text-orange-500 text-shadow-orange>
+            {{ $t('CreateStepsTipOrange') }}
+          </span>
+        </template>
+      </i18n> -->
+    </div>
+    <div
+      v-else
+      flex="~ row" flex-1 items-center justify-center text-center text-xl
+    >
+      <p
+        :class="recipe.mode === 'design' ? 'mode design-active text-white-500 text-shadow-white' : 'mode design'"
+        relative right--4.5 cursor-pointer self-center pt-0.5
+        @click="recipe.mode === 'raw' ? toggleMode() : null"
+      >
+        {{ $t('CreateDesign') }}
+      </p>
+      <p
+        :class="recipe.mode === 'raw' ? 'mode raw-active text-white-500 text-shadow-white' : 'mode raw'"
+        relative left--4.5 cursor-pointer self-center pt-0.5
+        @click="recipe.mode === 'design' ? toggleMode() : null"
+      >
+        {{ $t('CreateRaw') }}
+      </p>
+    </div>
+    <div
+      absolute cursor-pointer
+      :right="variant === 'ingredients' ? 2 : 4"
+      :h="variant === 'ingredients' ? 12 : 8"
+      :w="variant === 'ingredients' ? 12 : 8"
+      :class="variant === 'ingredients' ? 'i-ph-dots-three-bold orangeIcon' : 'i-ph-question-bold orangeIcon'"
+      @click="togglePanel"
+    />
+  </div>
+</template>
+
+<style scoped>
+.mode {
+  width: 100px;
+  height: 34px;
+  background-size: 100%;
+  background-repeat: no-repeat;
+  background-position: center;
+  margin: 0 10px;
+  z-index: 1;
+}
+
+.raw {
+  background-image: url('/assets/ModeRaw.svg');
+}
+
+.design {
+  background-image: url('/assets/ModeDesign.svg');
+}
+
+.raw-active {
+  background-image: url('/assets/ModeRawActive.svg');
+  background-size: 110%;
+  z-index: 2;
+}
+
+.design-active {
+  background-image: url('/assets/ModeDesignActive.svg');
+  background-size: 110%;
+  z-index: 2;
+}
+</style>

--- a/apps/frontend/Gump/components/SearchSelect.vue
+++ b/apps/frontend/Gump/components/SearchSelect.vue
@@ -1,0 +1,88 @@
+<script setup lang="ts">
+import Multiselect from '@vueform/multiselect'
+
+const prop = defineProps<{
+  model: string[]
+  options: string[]
+  mode: 'single' | 'multiple'
+}>()
+
+const emit = defineEmits<{
+  (event: 'update:model', ...args: any[]): void
+}>()
+
+function addTag(tag: string) {
+  if (prop.mode === 'multiple')
+    emit('update:model', [...prop.model, tag])
+  else if (prop.mode === 'single')
+    emit('update:model', [tag])
+}
+
+function removeTag(tag: string) {
+  if (prop.mode === 'multiple')
+    emit('update:model', prop.model.filter(t => t !== tag))
+}
+
+function handleBackspace(e: KeyboardEvent) {
+  if (e.key === 'Backspace')
+    emit('update:model', prop.model.slice(0, -1))
+}
+
+const option = ['pizza', 'pasta', 'salad', 'soup', 'dessert', 'drink']
+</script>
+
+<template>
+  <div mx-2 w-60>
+    <Multiselect
+      :value="model"
+      :options="mode === 'multiple' ? options : option"
+      :multiple="mode === 'multiple'"
+      :mode="mode === 'multiple' ? 'tags' : 'single'"
+      :taggable="mode === 'multiple'"
+      :create-option="mode === 'multiple'"
+      :show-options="mode === 'single'"
+      :searchable="true" :append-new-option="false"
+      class="select"
+      @tag="addTag"
+      @select="addTag"
+      @deselect="removeTag"
+      @keydown="handleBackspace"
+      @clear="$emit('update:model', [])"
+    />
+  </div>
+</template>
+
+<style scoped>
+.select {
+  --ms-bg: transparent;
+  --ms-radius: 10px;
+  --ms-border-width: 0px;
+  --ms-border-width-active: 0px;
+  --ms-ring-color: #F3582730;
+
+  --ms-spinner-color: #912808;
+  --ms-caret-color: #912808;
+  --ms-clear-color: #912808;
+  --ms-clear-color-hover: #2A1700;
+
+  --ms-tag-bg: #FCCAC0;
+  --ms-tag-color: #912808;
+  --ms-tag-radius: 9999px;
+
+  --ms-dropdown-bg: transparent;
+  --ms-dropdown-border-color: #F3582730;
+  --ms-dropdown-border-width: 1px;
+  --ms-dropdown-radius: 10px;
+
+  --ms-option-bg-pointed: #FEE5E3;
+  --ms-option-color-pointed: #912808c2;
+  --ms-option-bg-selected: #fccac0c2;
+  --ms-option-color-selected: #912808;
+  --ms-option-bg-selected-pointed: #fccac0c2;
+  --ms-option-color-selected-pointed: #912808c2;
+
+  box-shadow: inset 0px 2px 12px -4px rgb(243, 88, 39);
+}
+</style>
+
+<style src="@vueform/multiselect/themes/default.css"></style>

--- a/apps/frontend/Gump/nuxt.config.ts
+++ b/apps/frontend/Gump/nuxt.config.ts
@@ -62,13 +62,4 @@ export default defineNuxtConfig({
     langDir: '../../../locales/',
     defaultLocale: 'en',
   },
-  vite: {
-    vue: {
-      template: {
-        compilerOptions: {
-          isCustomElement: tag => ['vue-select'].includes(tag),
-        },
-      },
-    },
-  },
 })

--- a/apps/frontend/Gump/nuxt.config.ts
+++ b/apps/frontend/Gump/nuxt.config.ts
@@ -9,6 +9,9 @@ export default defineNuxtConfig({
     '@nuxtjs/ionic',
     'nuxt-vitest',
   ],
+  css: [
+    '@/assets/main.css',
+  ],
   pwa: {
     icon: false,
   },
@@ -49,9 +52,23 @@ export default defineNuxtConfig({
         file: 'ro_RO.json',
         name: 'Romanian',
       },
+      {
+        code: 'de',
+        file: 'de_DE.json',
+        name: 'German',
+      },
     ],
     lazy: true,
     langDir: '../../../locales/',
     defaultLocale: 'en',
+  },
+  vite: {
+    vue: {
+      template: {
+        compilerOptions: {
+          isCustomElement: tag => ['vue-select'].includes(tag),
+        },
+      },
+    },
   },
 })

--- a/apps/frontend/Gump/nuxt.config.ts
+++ b/apps/frontend/Gump/nuxt.config.ts
@@ -62,4 +62,13 @@ export default defineNuxtConfig({
     langDir: '../../../locales/',
     defaultLocale: 'en',
   },
+  vite: {
+    vue: {
+      template: {
+        compilerOptions: {
+          isCustomElement: tag => ['i18n'].includes(tag),
+        },
+      },
+    },
+  },
 })

--- a/apps/frontend/Gump/package.json
+++ b/apps/frontend/Gump/package.json
@@ -37,6 +37,7 @@
     "@capacitor/keyboard": "4.1.1",
     "@capacitor/status-bar": "4.1.1",
     "@pinia/nuxt": "^0.4.8",
+    "@vueform/multiselect": "^2.6.2",
     "pinia": "^2.0.34"
   },
   "overrides": {

--- a/apps/frontend/Gump/package.json
+++ b/apps/frontend/Gump/package.json
@@ -36,6 +36,7 @@
     "@capacitor/haptics": "4.1.0",
     "@capacitor/keyboard": "4.1.1",
     "@capacitor/status-bar": "4.1.1",
+    "@iconify-json/ph": "^1.1.5",
     "@pinia/nuxt": "^0.4.8",
     "@vueform/multiselect": "^2.6.2",
     "pinia": "^2.0.34"

--- a/apps/frontend/Gump/pages/home.vue
+++ b/apps/frontend/Gump/pages/home.vue
@@ -19,8 +19,17 @@ const recipe = useRecipeStore()
         <div class="i-fa6-solid-box-tissue" />
       </div>
       <TextInput v-model:text="recipe.recipe.title" />
+      <SearchSelect
+        v-model:model="recipe.recipe.categories"
+        :options="recipe.recipe.categories"
+        mode="single"
+      />
     </div>
     <MainButton mb-2 self-center color="orange" icon-type="create" title="Create recipe" />
     <TheNavbar />
   </ion-page>
 </template>
+
+<style scoped>
+
+</style>

--- a/apps/frontend/Gump/pages/recipes.vue
+++ b/apps/frontend/Gump/pages/recipes.vue
@@ -6,6 +6,8 @@
   <ion-page bg-crimson-50>
     <TheHeader :title="$t('RecipesNav')" />
     <div grow>
+      <CreateSubHeader variant="ingredients" />
+      <CreateSubHeader variant="steps" />
       <h1 text-crimson-500 text-shadow-crimson>
         {{ $t('RecipesNav') }}
       </h1>

--- a/apps/frontend/Gump/stores/recipe.ts
+++ b/apps/frontend/Gump/stores/recipe.ts
@@ -69,7 +69,7 @@ export const useRecipeStore = defineStore('recipe', () => {
     ...toRefs(state),
   }
 },
-// {
-//   persist: true,
-// }
+{
+  persist: true,
+},
 )

--- a/apps/frontend/Gump/stores/recipe.ts
+++ b/apps/frontend/Gump/stores/recipe.ts
@@ -30,6 +30,7 @@ export interface IRecipe {
 
 interface IRecipeState {
   recipe: IRecipe
+  mode: 'raw' | 'design'
 }
 
 export const useRecipeStore = defineStore('recipe', () => {
@@ -57,6 +58,7 @@ export const useRecipeStore = defineStore('recipe', () => {
       isPrivate: false,
       forks: [],
     },
+    mode: 'design',
   })
 
   // getters

--- a/apps/frontend/Gump/stores/recipe.ts
+++ b/apps/frontend/Gump/stores/recipe.ts
@@ -12,7 +12,7 @@ export interface IRecipe {
   image: number
   language: string
   serves: number
-  categories: number[]
+  categories: string[]
   tags: string[]
   ingredients: IIngredient[]
   steps: string[]
@@ -69,6 +69,7 @@ export const useRecipeStore = defineStore('recipe', () => {
     ...toRefs(state),
   }
 },
-{
-  persist: true,
-})
+// {
+//   persist: true,
+// }
+)

--- a/apps/frontend/Gump/tests/CreateSubHeader.nuxt.test.ts
+++ b/apps/frontend/Gump/tests/CreateSubHeader.nuxt.test.ts
@@ -1,0 +1,80 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { type VueWrapper, mount } from '@vue/test-utils'
+import type { ComponentPublicInstance } from 'vue'
+import { createI18n } from 'vue-i18n'
+import CreateSubHeader from '~/components/CreateSubHeader.vue'
+
+interface ICreateSubHeaderProps {
+  variant: 'ingredients' | 'steps'
+}
+
+describe('CreateSubHeader (ingredients)', () => {
+  let wrapper: VueWrapper<ComponentPublicInstance<ICreateSubHeaderProps>>
+
+  beforeEach(() => {
+    const i18n = createI18n ({
+      messages: {
+        en: {
+          tip: 'Tip',
+        },
+        ch: {
+          tip: '提示',
+        },
+      },
+    })
+    wrapper = mount(CreateSubHeader, {
+      attachTo: document.body,
+      props: {
+        variant: 'ingredients',
+      },
+      global: {
+        plugins: [i18n],
+      },
+    })
+  })
+
+  it('should render the title', () => {
+    expect(wrapper.html()).toContain('Ingredients')
+  })
+
+  it('should render the mode switcher', async () => {
+    await wrapper.find('.orangeIcon').trigger('click')
+    expect(wrapper.html()).toContain('Raw')
+    expect(wrapper.html()).toContain('Design')
+  })
+})
+
+describe('CreateSubHeader (steps)', () => {
+  let wrapper: VueWrapper<ComponentPublicInstance<ICreateSubHeaderProps>>
+
+  beforeEach(() => {
+    const i18n = createI18n ({
+      messages: {
+        en: {
+          tip: 'Tip',
+        },
+        ch: {
+          tip: '提示',
+        },
+      },
+    })
+    wrapper = mount(CreateSubHeader, {
+      attachTo: document.body,
+      props: {
+        variant: 'steps',
+      },
+      global: {
+        plugins: [i18n],
+      },
+    })
+  })
+
+  it('should render the title', () => {
+    expect(wrapper.html()).toContain('Steps')
+  })
+
+  it('should render the tip', async () => {
+    await wrapper.find('.orangeIcon').trigger('click')
+    expect(wrapper.html()).toContain('CreateStepsTip')
+  })
+})

--- a/apps/frontend/Gump/tests/MainButton.nuxt.test.ts
+++ b/apps/frontend/Gump/tests/MainButton.nuxt.test.ts
@@ -1,11 +1,8 @@
 import { describe, expect, it } from 'vitest'
-import { setup } from '@nuxt/test-utils'
 import { mount } from '@vue/test-utils'
 import MainButton from '~/components/MainButton.vue'
 
 describe('MainButton', () => {
-  setup()
-
   it('should render the title prop', () => {
     const wrapper = mount(MainButton, {
       props: {

--- a/apps/frontend/Gump/tests/SearchSelect.nuxt.test.ts
+++ b/apps/frontend/Gump/tests/SearchSelect.nuxt.test.ts
@@ -1,0 +1,96 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { type VueWrapper, mount } from '@vue/test-utils'
+import type { ComponentPublicInstance } from 'vue'
+import SearchSelect from '~/components/SearchSelect.vue'
+
+interface ISearchSelectProps {
+  model: string[]
+  options: string[]
+  mode: 'single' | 'multiple'
+}
+
+describe('SearchSelect (multiple)', () => {
+  let wrapper: VueWrapper<ComponentPublicInstance<ISearchSelectProps>>
+
+  beforeEach(() => {
+    wrapper = mount(SearchSelect, {
+      attachTo: document.body,
+      props: {
+        model: [],
+        options: ['pizza', 'pasta', 'salad'],
+        mode: 'multiple',
+      },
+    })
+  })
+
+  it('should render the options prop', () => {
+    expect(wrapper.html()).toContain('pizza')
+    expect(wrapper.html()).toContain('pasta')
+    expect(wrapper.html()).toContain('salad')
+  })
+
+  it('should add a tag when an option is selected', async () => {
+    await wrapper.find('#multiselect-option-pizza').trigger('click')
+    expect(wrapper.emitted()['update:model'][0]).toEqual([['pizza']])
+  })
+
+  it('should remove a tag when an option is deselected', async () => {
+    await wrapper.setProps({ model: ['pizza'] })
+    const pizzaTag = wrapper.find('.multiselect-tag')
+    const xmarkIcon = pizzaTag.find('.multiselect-tag-remove')
+    await xmarkIcon.trigger('click')
+    expect(wrapper.emitted()['update:model'][0]).toEqual([[]])
+  })
+
+  it('should create a new option when a tag is entered', async () => {
+    await wrapper.find('input').setValue('burger')
+    await wrapper.find('input').trigger('keydown.enter')
+    expect(wrapper.html()).toContain('burger')
+  })
+
+  it('should clear all tags when the clear button is clicked', async () => {
+    await wrapper.setProps({ model: ['pizza', 'pasta'] })
+    await wrapper.find('.multiselect-clear').trigger('click')
+    expect(wrapper.emitted()['update:model'][0]).toEqual([[]])
+  })
+})
+
+describe('SearchSelect (single)', () => {
+  let wrapper: VueWrapper<ComponentPublicInstance<ISearchSelectProps>>
+
+  beforeEach(() => {
+    wrapper = mount(SearchSelect, {
+      attachTo: document.body,
+      props: {
+        model: [],
+        options: ['pizza', 'pasta', 'salad'],
+        mode: 'single',
+      },
+    })
+  })
+
+  it('should render the options prop', () => {
+    expect(wrapper.html()).toContain('pizza')
+    expect(wrapper.html()).toContain('pasta')
+    expect(wrapper.html()).toContain('salad')
+  })
+
+  it('should add a tag when an option is selected', async () => {
+    await wrapper.find('#multiselect-option-pizza').trigger('click')
+    expect(wrapper.emitted()['update:model'][0]).toEqual([['pizza']])
+  })
+
+  it('should display the option when searching', async () => {
+    await wrapper.find('input').setValue('pizza')
+    const pizzaOption = wrapper.find('#multiselect-option-pizza') // the pizza option
+    const caret = wrapper.find('.multiselect-caret.is-open') // open dropdown
+    expect(pizzaOption.exists()).toBe(true)
+    expect(caret.exists()).toBe(true)
+  })
+
+  it('should clear the selected option when the clear button is clicked', async () => {
+    await wrapper.setProps({ model: ['pizza'] })
+    await wrapper.find('.multiselect-clear').trigger('click')
+    expect(wrapper.emitted()['update:model'][0]).toEqual([[]])
+  })
+})

--- a/apps/frontend/Gump/tests/TextInput.nuxt.test.ts
+++ b/apps/frontend/Gump/tests/TextInput.nuxt.test.ts
@@ -1,9 +1,15 @@
 import { beforeEach, describe, expect, it } from 'vitest'
-import { mount } from '@vue/test-utils'
+import { type VueWrapper, mount } from '@vue/test-utils'
+import type { ComponentPublicInstance } from 'vue'
 import TextInput from '~/components/TextInput.vue'
 
+interface ITextInputProps {
+  text: string
+  type?: 'email' | 'password'
+}
+
 describe('TextInput', () => {
-  let wrapper: any
+  let wrapper: VueWrapper<ComponentPublicInstance<ITextInputProps>>
 
   beforeEach(() => {
     wrapper = mount(TextInput, {
@@ -28,6 +34,6 @@ describe('TextInput', () => {
     const input = wrapper.find('input')
     await input.setValue('World')
     expect(wrapper.emitted()).toHaveProperty('update:text')
-    expect(wrapper.emitted('update:text')[0][0]).toBe('World')
+    expect(wrapper.emitted('update:text')![0][0]).toBe('World')
   })
 })

--- a/locales/en_US.json
+++ b/locales/en_US.json
@@ -17,7 +17,7 @@
   "CreateVisibilityPrivateTitle": "Private",
   "CreateVisibilityPrivateDesc": "only you and people you share it with can view your recipe",
   "CreateLanguage": "Language",
-  "CreateDesgin": "Design",
+  "CreateDesign": "Design",
   "CreateRaw": "Raw",
   "CreateItemButton": "Add item",
   "CreateIngredients": "Ingredients",

--- a/locales/hu_HU.json
+++ b/locales/hu_HU.json
@@ -23,7 +23,7 @@
   "CreateVisibilityPublicDesc": "mindenki láthatja a receptedet, de csak te szerkesztheted",
   "CreateVisibilityPrivateDesc": "csak te és azok, akikkel megosztod, láthatják a receptedet",
   "CreateLanguage": "Nyelv",
-  "CreateDesgin": "Tervezés",
+  "CreateDesign": "Tervezés",
   "CreateRaw": "Nyers",
   "CreateItemButton": "Elem hozzáadása",
   "CreateIngredients": "Hozzávalók",


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 4c7ed4a</samp>

### Summary
🎨🚀✨

<!--
1.  🎨 - This emoji is often used to indicate changes related to the UI, design, or style of the app. It could be used for the first, third, and fifth changes, as they all involve adding or modifying CSS rules, components, or libraries that affect the appearance of the app.
2.  🚀 - This emoji is often used to indicate changes related to the performance, speed, or optimization of the app. It could be used for the fifth change, as it involves adding vite configuration to the `nuxt.config.ts` file, which is a tool that improves the development and production experience of the app.
3.  ✨ - This emoji is often used to indicate changes related to the introduction of new features, enhancements, or improvements to the app. It could be used for the second, fourth, and sixth changes, as they all involve adding new components, functionality, or options to the app.
-->
This pull request adds several features and improvements to the frontend app, such as user-defined recipe categories, multilingual support, global CSS, and vite configuration. It also creates two new Vue components, `CreateSubHeader` and `SearchSelect`, to enhance the user interface and functionality of the recipe creation page. Additionally, it fixes a syntax error in the recipe store and adds some styling to the input elements.

> _We're building a recipe app with Vue and Nuxt_
> _We're adding components, styles, and features as we go_
> _We're heaving on the `CreateSubHeader` and the `SearchSelect`_
> _We're working hard to make it look and work perfect_

### Walkthrough
*  Add two new Vue components, CreateSubHeader and SearchSelect, to display and interact with the recipe creation page ([link](https://github.com/14A-A-Lyedlik-Devs/Gump/pull/482/files?diff=unified&w=0#diff-bd19579211ab0a30ef8f518c636d86a8daf404396e576e14d79954e2033fc82dR1-R105), [link](https://github.com/14A-A-Lyedlik-Devs/Gump/pull/482/files?diff=unified&w=0#diff-87fcc2a676158e86d1e0408138f9b35f1de0d2852173683197c50f60663e563eR1-R88))
*  Use the CreateSubHeader component in the `recipes.vue` page, and pass the variant prop as either ingredients or steps ([link](https://github.com/14A-A-Lyedlik-Devs/Gump/pull/482/files?diff=unified&w=0#diff-224226079ae675007cdd703ba746fcb4640304e21a29429092239f070659ddb5R9-R10))
*  Add a new mode property to the recipe store, which represents the current mode of the recipe creation page ([link](https://github.com/14A-A-Lyedlik-Devs/Gump/pull/482/files?diff=unified&w=0#diff-fff9d1299723af9e15255bb8947c21b5d5453a9ef83d63926b63ae8b8f456b2eR33), [link](https://github.com/14A-A-Lyedlik-Devs/Gump/pull/482/files?diff=unified&w=0#diff-fff9d1299723af9e15255bb8947c21b5d5453a9ef83d63926b63ae8b8f456b2eR61))
*  Add a CSS rule to make the input elements have a transparent background in `main.css` ([link](https://github.com/14A-A-Lyedlik-Devs/Gump/pull/482/files?diff=unified&w=0#diff-c4d754ec6146163f99fcfa1dd20dc02e08fe4ec30ecdfdbd6799f7effeff4087L1-R2))
*  Add the `main.css` file to the global CSS configuration of the Nuxt app in `nuxt.config.ts` ([link](https://github.com/14A-A-Lyedlik-Devs/Gump/pull/482/files?diff=unified&w=0#diff-7cc25f413b350c923da4c68e6215dc8a8ffabb8b616c8326715e6899263ad22cR12-R14))
*  Add the German language option to the i18n configuration of the Nuxt app in `nuxt.config.ts` ([link](https://github.com/14A-A-Lyedlik-Devs/Gump/pull/482/files?diff=unified&w=0#diff-7cc25f413b350c923da4c68e6215dc8a8ffabb8b616c8326715e6899263ad22cR55-R59))
*  Add a vite configuration to the Nuxt app in `nuxt.config.ts`, which specifies that the i18n tag is a custom element ([link](https://github.com/14A-A-Lyedlik-Devs/Gump/pull/482/files?diff=unified&w=0#diff-7cc25f413b350c923da4c68e6215dc8a8ffabb8b616c8326715e6899263ad22cR65-R73))
*  Change the type of the categories property in the IRecipe interface from number[] to string[] in the recipe store ([link](https://github.com/14A-A-Lyedlik-Devs/Gump/pull/482/files?diff=unified&w=0#diff-fff9d1299723af9e15255bb8947c21b5d5453a9ef83d63926b63ae8b8f456b2eL15-R15))
*  Add an empty style tag to the `home.vue` page, which is a placeholder for future styling ([link](https://github.com/14A-A-Lyedlik-Devs/Gump/pull/482/files?diff=unified&w=0#diff-d7c7cba00436b50ec11b988659397e360494f56d2f53f7b17812723e4b13ec8bR32-R35))
*  Fix a syntax error in the useRecipeStore function in the recipe store ([link](https://github.com/14A-A-Lyedlik-Devs/Gump/pull/482/files?diff=unified&w=0#diff-fff9d1299723af9e15255bb8947c21b5d5453a9ef83d63926b63ae8b8f456b2eL74-R77))


