### PR TITLE
487 searchselect refactor + backspace bug

### DIFF
--- a/apps/frontend/Gump/components/SearchSelect.vue
+++ b/apps/frontend/Gump/components/SearchSelect.vue
@@ -4,7 +4,7 @@ import Multiselect from '@vueform/multiselect'
 const prop = defineProps<{
   model: string[]
   options: string[]
-  mode: 'single' | 'multiple'
+  mode: 'multiple' | 'tags'
 }>()
 
 const emit = defineEmits<{
@@ -12,19 +12,15 @@ const emit = defineEmits<{
 }>()
 
 function addTag(tag: string) {
-  if (prop.mode === 'multiple')
-    emit('update:model', [...prop.model, tag])
-  else if (prop.mode === 'single')
-    emit('update:model', [tag])
+  emit('update:model', [...prop.model, tag])
 }
 
 function removeTag(tag: string) {
-  if (prop.mode === 'multiple')
-    emit('update:model', prop.model.filter(t => t !== tag))
+  emit('update:model', prop.model.filter(t => t !== tag))
 }
 
 function handleBackspace(e: KeyboardEvent) {
-  if (e.key === 'Backspace')
+  if (e.key === 'Backspace' && (e.target as HTMLInputElement).value === '')
     emit('update:model', prop.model.slice(0, -1))
 }
 
@@ -35,13 +31,15 @@ const option = ['pizza', 'pasta', 'salad', 'soup', 'dessert', 'drink']
   <div mx-2 w-60>
     <Multiselect
       :value="model"
-      :options="mode === 'multiple' ? options : option"
-      :multiple="mode === 'multiple'"
-      :mode="mode === 'multiple' ? 'tags' : 'single'"
-      :taggable="mode === 'multiple'"
-      :create-option="mode === 'multiple'"
-      :show-options="mode === 'single'"
+      :options="mode === 'tags' ? options : option"
+      :multiple="true"
+      :taggable="true"
+      :create-option="mode === 'tags'"
+      :show-options="mode === 'multiple'"
       :searchable="true" :append-new-option="false"
+      :close-on-select="false"
+      :close-on-deselect="false"
+      mode="tags"
       class="select"
       @tag="addTag"
       @select="addTag"

--- a/apps/frontend/Gump/pages/home.vue
+++ b/apps/frontend/Gump/pages/home.vue
@@ -22,7 +22,7 @@ const recipe = useRecipeStore()
       <SearchSelect
         v-model:model="recipe.recipe.categories"
         :options="recipe.recipe.categories"
-        mode="single"
+        mode="multiple"
       />
     </div>
     <MainButton mb-2 self-center color="orange" icon-type="create" title="Create recipe" />

--- a/apps/frontend/Gump/stores/ui.ts
+++ b/apps/frontend/Gump/stores/ui.ts
@@ -41,9 +41,9 @@ export const useUIStore = defineStore('ui', () => {
   // getters
   const getSearchHistory = computed(() => {
     if (state.searchHistory.length > 5)
-      return state.searchHistory.slice(state.searchHistory.length - 5)
+      return state.searchHistory.slice(state.searchHistory.length - 5).reverse()
     else
-      return state.searchHistory
+      return state.searchHistory.slice().reverse()
   })
 
   // actions

--- a/apps/frontend/Gump/tests/SearchSelect.nuxt.test.ts
+++ b/apps/frontend/Gump/tests/SearchSelect.nuxt.test.ts
@@ -86,7 +86,6 @@ describe('SearchSelect (multiple)', () => {
     const caret = wrapper.find('.multiselect-caret.is-open') // open dropdown
     expect(pizzaOption.exists()).toBe(true)
     expect(caret.exists()).toBe(true)
-    console.log(wrapper.html())
   })
 
   it('should clear the selected option when the clear button is clicked', async () => {

--- a/apps/frontend/Gump/tests/SearchSelect.nuxt.test.ts
+++ b/apps/frontend/Gump/tests/SearchSelect.nuxt.test.ts
@@ -6,10 +6,10 @@ import SearchSelect from '~/components/SearchSelect.vue'
 interface ISearchSelectProps {
   model: string[]
   options: string[]
-  mode: 'single' | 'multiple'
+  mode: 'multiple' | 'tags'
 }
 
-describe('SearchSelect (multiple)', () => {
+describe('SearchSelect (tags)', () => {
   let wrapper: VueWrapper<ComponentPublicInstance<ISearchSelectProps>>
 
   beforeEach(() => {
@@ -18,7 +18,7 @@ describe('SearchSelect (multiple)', () => {
       props: {
         model: [],
         options: ['pizza', 'pasta', 'salad'],
-        mode: 'multiple',
+        mode: 'tags',
       },
     })
   })
@@ -55,7 +55,7 @@ describe('SearchSelect (multiple)', () => {
   })
 })
 
-describe('SearchSelect (single)', () => {
+describe('SearchSelect (multiple)', () => {
   let wrapper: VueWrapper<ComponentPublicInstance<ISearchSelectProps>>
 
   beforeEach(() => {
@@ -64,7 +64,7 @@ describe('SearchSelect (single)', () => {
       props: {
         model: [],
         options: ['pizza', 'pasta', 'salad'],
-        mode: 'single',
+        mode: 'multiple',
       },
     })
   })
@@ -86,6 +86,7 @@ describe('SearchSelect (single)', () => {
     const caret = wrapper.find('.multiselect-caret.is-open') // open dropdown
     expect(pizzaOption.exists()).toBe(true)
     expect(caret.exists()).toBe(true)
+    console.log(wrapper.html())
   })
 
   it('should clear the selected option when the clear button is clicked', async () => {


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at d1709e5</samp>

### Summary
🔄🗃️🏷️

<!--
1.  🔄 - This emoji represents the change of reversing the order of the search history array. It can be used to indicate a reversal, a rotation, or a refresh of something.
2.  🗃️ - This emoji represents the change of using the `multiple` mode for the `SearchSelect` component. It can be used to indicate a selection, a collection, or a grouping of multiple items.
3.  🏷️ - This emoji represents the enhancement of adding the `tags` mode for the `SearchSelect` component. It can be used to indicate a label, a tag, or a custom input.
-->
Enhanced the `SearchSelect` component to support multiple selection and custom tags, and used it in the `home.vue` page for recipe search. Also improved the order of the search history in the `ui.ts` store.

> _Sing to me, O Muse, of the skillful coder who changed the SearchSelect_
> _To offer multiple choices and custom tags, as the user's project_
> _He altered the ui store, to show the latest searches first_
> _Like Hermes, swift and cunning, he improved the user's thirst_

### Walkthrough
*  Change the `mode` prop of the `SearchSelect` component to support multiple selection and tag creation features ([link](https://github.com/14A-A-Lyedlik-Devs/Gump/pull/488/files?diff=unified&w=0#diff-87fcc2a676158e86d1e0408138f9b35f1de0d2852173683197c50f60663e563eL7-R7))
*  Simplify the tag-related functions and prevent accidental deletion of tags in the `SearchSelect` component ([link](https://github.com/14A-A-Lyedlik-Devs/Gump/pull/488/files?diff=unified&w=0#diff-87fcc2a676158e86d1e0408138f9b35f1de0d2852173683197c50f60663e563eL15-R23), [link](https://github.com/14A-A-Lyedlik-Devs/Gump/pull/488/files?diff=unified&w=0#diff-87fcc2a676158e86d1e0408138f9b35f1de0d2852173683197c50f60663e563eL38-R42))
*  Update the `Multiselect` component props to enable the new `mode` values and improve the user experience in the `SearchSelect` component ([link](https://github.com/14A-A-Lyedlik-Devs/Gump/pull/488/files?diff=unified&w=0#diff-87fcc2a676158e86d1e0408138f9b35f1de0d2852173683197c50f60663e563eL38-R42))
*  Use the `multiple` mode for the `SearchSelect` component in the `home.vue` page to allow selecting multiple categories for the recipe search ([link](https://github.com/14A-A-Lyedlik-Devs/Gump/pull/488/files?diff=unified&w=0#diff-d7c7cba00436b50ec11b988659397e360494f56d2f53f7b17812723e4b13ec8bL25-R25))
*  Reverse the order of the search history array in the `ui.ts` store to show the most recent searches first in the `SearchSelect` component ([link](https://github.com/14A-A-Lyedlik-Devs/Gump/pull/488/files?diff=unified&w=0#diff-51c2edcfdddf30bd8958554fb52c8d1e3b795743314b1b06a31a48cfe795ace4L44-R46))


