### PR TITLE
kész

### DIFF
--- a/apps/frontend/Gump/components/CreateSubHeader.vue
+++ b/apps/frontend/Gump/components/CreateSubHeader.vue
@@ -66,7 +66,8 @@ function toggleMode() {
       :right="variant === 'ingredients' ? 2 : 4"
       :h="variant === 'ingredients' ? 12 : 8"
       :w="variant === 'ingredients' ? 12 : 8"
-      :class="variant === 'ingredients' ? 'i-ph-dots-three-bold orangeIcon' : 'i-ph-question-bold orangeIcon'"
+      class="orangeIcon"
+      :class="variant === 'ingredients' ? 'i-ph-dots-three-bold' : 'i-ph-question-bold'"
       @click="togglePanel"
     />
   </div>

--- a/apps/frontend/Gump/components/RecipeFooter.vue
+++ b/apps/frontend/Gump/components/RecipeFooter.vue
@@ -1,0 +1,44 @@
+<script setup lang="ts">
+defineProps<{
+  viewCount: number
+  likeCount: number
+  saveCount: number
+  isLiked: boolean
+  isSaved: boolean
+}>()
+
+defineEmits<{
+  (event: 'like'): void
+  (event: 'save'): void
+}>()
+
+const likeButton = ref<HTMLElement>()
+const saveButton = ref<HTMLElement>()
+</script>
+
+<template>
+  <div flex="~ row" justify-between font-mono text-2xl>
+    <div flex="~ row" items-center>
+      <div h-8 w-8 class="i-fa6-solid-eye orangeIcon" />
+      <div ml-1 text-orange-500>
+        {{ formatNumber(viewCount) }}
+      </div>
+    </div>
+    <div ref="likeButton" flex="~ row" cursor-pointer items-center @click="$emit('like')">
+      <div h-8 w-8 class="crimsonIcon" :class="isLiked ? 'i-ph-heart-fill' : 'i-ph-heart-bold'" />
+      <div ml-1 text-crimson-500>
+        {{ formatNumber(likeCount) }}
+      </div>
+    </div>
+    <div ref="saveButton" flex="~ row" cursor-pointer items-center @click="$emit('save')">
+      <div h-8 w-8 class="blueIcon" :class="isSaved ? 'i-ph-bookmark-simple-fill' : 'i-ph-bookmark-simple-bold'" />
+      <div ml-1 text-blue-500>
+        {{ formatNumber(saveCount) }}
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+
+</style>

--- a/apps/frontend/Gump/components/TheHeader.vue
+++ b/apps/frontend/Gump/components/TheHeader.vue
@@ -52,7 +52,8 @@ const icons = ['i-fa6-solid-fire', 'i-ion-sparkles', 'i-fa6-solid-trophy']
         <div
           v-for="(sort, index) in sorts"
           :key="sort"
-          :class="`${icons[index]} orangeIcon ${ui.activeSort === sort ? 'active' : ''}`"
+          class="orangeIcon"
+          :class="`${icons[index]} ${ui.activeSort === sort ? 'active' : ''}`"
           @click="ui.activeSort = sort"
         />
       </div>

--- a/apps/frontend/Gump/composables/formatNumber.ts
+++ b/apps/frontend/Gump/composables/formatNumber.ts
@@ -1,0 +1,16 @@
+/**
+ * Format a number to a short string with a suffix (k, M, B, T), and keep it to 3 digits
+ * @param value The number to format
+ * @returns The formatted number
+ * @example
+ * formatNumber(123) // 123
+ * formatNumber(1234) // 1.23k
+ * formatNumber(12345) // 12.3k
+ * formatNumber(123456) // 123k
+ */
+export function formatNumber(value: number): string {
+  const ending = [' ', 'k', 'M', 'B', 'T']
+  const suffix = Math.floor((`${value}`).length / 4)
+  const shortValue = parseFloat((suffix !== 0 ? (value / 1000 ** suffix) : value).toPrecision(3))
+  return shortValue + ending[suffix]
+}

--- a/apps/frontend/Gump/pages/home.vue
+++ b/apps/frontend/Gump/pages/home.vue
@@ -24,6 +24,9 @@ const recipe = useRecipeStore()
         :options="recipe.recipe.categories"
         mode="multiple"
       />
+      <div mt-4 w-full>
+        <RecipeFooter :view-count="32500000" :like-count="1234" :save-count="123456789" :is-liked="false" :is-saved="false" />
+      </div>
     </div>
     <MainButton mb-2 self-center color="orange" icon-type="create" title="Create recipe" />
     <TheNavbar />

--- a/apps/frontend/Gump/tests/RecipeFooter.nuxt.test.ts
+++ b/apps/frontend/Gump/tests/RecipeFooter.nuxt.test.ts
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { type VueWrapper, mount } from '@vue/test-utils'
+import type { ComponentPublicInstance } from 'vue'
+import RecipeFooter from '~/components/RecipeFooter.vue'
+
+interface IRecipeFooterProps {
+  viewCount: number
+  likeCount: number
+  saveCount: number
+  isLiked: boolean
+  isSaved: boolean
+}
+
+describe('RecipeFooter', () => {
+  let wrapper: VueWrapper<ComponentPublicInstance<IRecipeFooterProps>>
+
+  beforeEach(() => {
+    wrapper = mount(RecipeFooter, {
+      attachTo: document.body,
+      props: {
+        viewCount: 123,
+        likeCount: 1234,
+        saveCount: 12345,
+        isLiked: false,
+        isSaved: false,
+      },
+    })
+  })
+
+  it('should have the correct props', () => {
+    expect(wrapper.props()).toEqual({
+      viewCount: 123,
+      likeCount: 1234,
+      saveCount: 12345,
+      isLiked: false,
+      isSaved: false,
+    })
+  })
+
+  it('should render the counts in the correct format', () => {
+    expect(wrapper.html()).toContain('123')
+    expect(wrapper.html()).toContain('1.23k')
+    expect(wrapper.html()).toContain('12.3k')
+  })
+
+  it('should change the icons when the props change', async () => {
+    const likeIcon = wrapper.find('.crimsonIcon')
+    const saveIcon = wrapper.find('.blueIcon')
+
+    expect(likeIcon.classes()).toContain('i-ph-heart-bold')
+    expect(saveIcon.classes()).toContain('i-ph-bookmark-simple-bold')
+
+    await wrapper.setProps({ isLiked: true, isSaved: true })
+
+    expect(likeIcon.classes()).toContain('i-ph-heart-fill')
+    expect(saveIcon.classes()).toContain('i-ph-bookmark-simple-fill')
+  })
+
+  it('should emit an event when the icons are clicked', async () => {
+    const likeButton = wrapper.find({ ref: 'likeButton' })
+    const saveButton = wrapper.find({ ref: 'saveButton' })
+
+    await likeButton.trigger('click')
+    await saveButton.trigger('click')
+
+    expect(wrapper.emitted()).toHaveProperty('like')
+    expect(wrapper.emitted()).toHaveProperty('save')
+  })
+})

--- a/apps/frontend/Gump/uno.config.ts
+++ b/apps/frontend/Gump/uno.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
     presetWebFonts({
       fonts: {
         sans: 'Ubuntu',
+        mono: 'Single Day',
       },
     }),
   ],


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at e4820b8</samp>

### Summary
🎨🍽️📊

<!--
1.  🎨 - This emoji represents the change of moving the `orangeIcon` class to a separate attribute, which is a stylistic improvement that makes the code more readable and consistent.
2.  🍽️ - This emoji represents the addition of the `RecipeFooter` component, which is a feature that enhances the user experience by showing the popularity and actions of a recipe.
3.  📊 - This emoji represents the addition of the `formatNumber` function and the `mono` font family, which are both utilities that help display numerical data in a concise and appealing way.
-->
This pull request adds a new `RecipeFooter` component to display the statistics and actions of a recipe, and uses a `formatNumber` function to format the numbers. It also refactors the `orangeIcon` class in two existing components to improve readability, and adds a new font family to the global styles.

> _`RecipeFooter` shows_
> _views, likes, saves with `mono`_
> _orange icons shine_

### Walkthrough
*  Add `RecipeFooter` component to display recipe stats and actions ([link](https://github.com/14A-A-Lyedlik-Devs/Gump/pull/492/files?diff=unified&w=0#diff-e77860a2944202b00762266abd0d297760e907d1c7563c7bb92ed17879064c4bR1-R44), [link](https://github.com/14A-A-Lyedlik-Devs/Gump/pull/492/files?diff=unified&w=0#diff-d7c7cba00436b50ec11b988659397e360494f56d2f53f7b17812723e4b13ec8bR27-R29))
  - Use `formatNumber` function from `composables` folder to format counts with suffixes ([link](https://github.com/14A-A-Lyedlik-Devs/Gump/pull/492/files?diff=unified&w=0#diff-7d97bff736e4430fb17b3841bd2131b956f447a71c80c4132d2b390b91949269R1-R16))
  - Use `mono` font family from `uno.config.ts` file for counts ([link](https://github.com/14A-A-Lyedlik-Devs/Gump/pull/492/files?diff=unified&w=0#diff-d035ad7c1c48e1ad58080c58bc407bc59700df93c7f14d1e8790e0b2ee51bcfdR11))
* Move `orangeIcon` class to separate attribute in `CreateSubHeader` and `TheHeader` components to improve readability ([link](https://github.com/14A-A-Lyedlik-Devs/Gump/pull/492/files?diff=unified&w=0#diff-bd19579211ab0a30ef8f518c636d86a8daf404396e576e14d79954e2033fc82dL69-R70), [link](https://github.com/14A-A-Lyedlik-Devs/Gump/pull/492/files?diff=unified&w=0#diff-2c53a281d7f49874c0ed3246e83d4721581bab378a0373fd028a56de2df1ec9bL55-R56))


