### PR TITLE
425 createheader

### DIFF
--- a/apps/frontend/Gump/components/CreateHeader.vue
+++ b/apps/frontend/Gump/components/CreateHeader.vue
@@ -1,0 +1,62 @@
+<script setup lang="ts">
+import { useUIStore } from '~/stores/ui'
+
+const ui = useUIStore()
+
+const currentPage = computed(() => ui.createHeaderInex)
+
+function trueCreate() {
+  ui.setCreateHeaderStates(true, currentPage.value - 1)
+}
+
+function falseCreate() {
+  ui.setCreateHeaderStates(false, currentPage.value - 1)
+}
+</script>
+
+<template>
+  <div flex="~ row" h-20 w-full items-center justify-center gap-10 bg-crimson-50 p-2 px-3 shadow-orange>
+    <div v-for="n in 4" :key="n" cursor-pointer :class="[ui.createHeaderStates[n - 1] ? 'done' : 'empty']" @click="ui.setCreateHeaderIndex(n)">
+      <div v-if="n === ui.createHeaderInex" class="active" />
+    </div>
+  </div>
+  <div mt-10 flex gap-5>
+    <button @click="trueCreate">
+      Set True
+    </button>
+    <button @click="falseCreate">
+      Set False
+    </button>
+  </div>
+</template>
+
+<style scoped>
+.empty {
+  width: 70px;
+  height: 20px;
+
+  background: #7A6662;
+  box-shadow: 0px 5px 12px -3px rgba(122, 102, 98, 0.6);
+  border-radius: 50px;
+}
+
+.done {
+  width: 70px;
+  height: 20px;
+
+  background: linear-gradient(90deg, #F37927 0%, #D12C5F 460.71%);
+  box-shadow: 0px 5px 12px -3px rgba(243, 88, 39, 0.6);
+  border-radius: 50px;
+}
+
+.active {
+  width: 90px;
+  height: 40px;
+
+  border: 4px solid rgba(33, 8, 0, 0.9);
+  box-shadow: 0px 5px 12px -4px rgba(243, 88, 39, 0.5);
+  border-radius: 50px;
+  margin-top: -10px;
+  margin-left: -10px;
+}
+</style>

--- a/apps/frontend/Gump/components/CreateHeader.vue
+++ b/apps/frontend/Gump/components/CreateHeader.vue
@@ -3,7 +3,7 @@ import { useUIStore } from '~/stores/ui'
 
 const ui = useUIStore()
 
-const currentPage = computed(() => ui.createHeaderInex)
+const currentPage = computed(() => ui.createHeaderIndex)
 
 function trueCreate() {
   ui.setCreateHeaderStates(true, currentPage.value - 1)
@@ -17,7 +17,7 @@ function falseCreate() {
 <template>
   <div flex="~ row" h-20 w-full items-center justify-center gap-10 bg-crimson-50 p-2 px-3 shadow-orange>
     <div v-for="n in 4" :key="n" cursor-pointer :class="[ui.createHeaderStates[n - 1] ? 'done' : 'empty']" @click="ui.setCreateHeaderIndex(n)">
-      <div v-if="n === ui.createHeaderInex" class="active" />
+      <div v-if="n === ui.createHeaderIndex" class="active" />
     </div>
   </div>
   <div mt-10 flex gap-5>

--- a/apps/frontend/Gump/pages/create.vue
+++ b/apps/frontend/Gump/pages/create.vue
@@ -4,7 +4,7 @@
 
 <template>
   <ion-page bg-crimson-50>
-    <TheHeader :title="$t('CreateNav')" />
+    <CreateHeader />
     <div grow>
       <h1 text-crimson-500 text-shadow-crimson>
         {{ $t('CreateNav') }}

--- a/apps/frontend/Gump/stores/ui.ts
+++ b/apps/frontend/Gump/stores/ui.ts
@@ -25,6 +25,8 @@ interface IUIState {
   dropdownToggled: boolean
   searchValue: string
   searchHistory: string[]
+  createHeaderIndex: number
+  createHeaderStates: boolean[]
 }
 
 export const useUIStore = defineStore('ui', () => {
@@ -36,6 +38,8 @@ export const useUIStore = defineStore('ui', () => {
     dropdownToggled: false,
     searchValue: '',
     searchHistory: [],
+    createHeaderIndex: 1,
+    createHeaderStates: [false, false, false, false],
   })
 
   // getters
@@ -55,6 +59,14 @@ export const useUIStore = defineStore('ui', () => {
     state.activeSort = sort
   }
 
+  const setCreateHeaderIndex = (index: number) => {
+    state.createHeaderIndex = index
+  }
+
+  const setCreateHeaderStates = (value: boolean, index: number) => {
+    state.createHeaderStates[index] = value
+  }
+
   const addSearchHistory = (value: string) => {
     if (state.searchHistory.includes(value) || value === '')
       return
@@ -71,6 +83,8 @@ export const useUIStore = defineStore('ui', () => {
     setActiveNav,
     setActiveSort,
     addSearchHistory,
+    setCreateHeaderIndex,
+    setCreateHeaderStates,
   }
 },
 {


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 3800b98</samp>

### Summary
🆕🔄🛠️

<!--
1.  🆕 for adding a new component
2.  🔄 for replacing an existing component
3.  🛠️ for adding and exposing new state properties and methods
-->
This pull request adds a progress indicator for the create page in the frontend app. It introduces a new component `CreateHeader.vue` that uses the `ui.ts` store module to manage the navigation and completion status of the create page. It also updates the `create.vue` page to use the new component and removes some redundant code.

> _Sing, O Muse, of the skilled developer who wrought_
> _A new component, `CreateHeader`, to display_
> _The progress of the create page, and who taught_
> _The `ui` store to guide the user on their way._

### Walkthrough
*  Add a new component `CreateHeader.vue` to display a progress indicator for the create page ([link](https://github.com/14A-A-Lyedlik-Devs/Gump/pull/495/files?diff=unified&w=0#diff-9bb0715143bbbdc1b27ed429e8f16b23d8c0a433909e4aa9b5d877c2df87a1c3R1-R62))
*  Replace `TheHeader` with `CreateHeader` in the `create.vue` page to integrate the progress indicator ([link](https://github.com/14A-A-Lyedlik-Devs/Gump/pull/495/files?diff=unified&w=0#diff-323fa6e125ac78216ea50f13cedc453074da24aff8ae106e04abc309478cac3dL7-R7))
*  Add and initialize two new properties `createHeaderIndex` and `createHeaderStates` to the `IUIState` interface and the `useUIStore` hook in the `ui.ts` store module to store the state of the create page ([link](https://github.com/14A-A-Lyedlik-Devs/Gump/pull/495/files?diff=unified&w=0#diff-51c2edcfdddf30bd8958554fb52c8d1e3b795743314b1b06a31a48cfe795ace4R28-R29), [link](https://github.com/14A-A-Lyedlik-Devs/Gump/pull/495/files?diff=unified&w=0#diff-51c2edcfdddf30bd8958554fb52c8d1e3b795743314b1b06a31a48cfe795ace4R41-R42))
*  Add and expose two new methods `setCreateHeaderIndex` and `setCreateHeaderStates` to the `useUIStore` hook to manipulate the state of the create page from the `CreateHeader` component or other components ([link](https://github.com/14A-A-Lyedlik-Devs/Gump/pull/495/files?diff=unified&w=0#diff-51c2edcfdddf30bd8958554fb52c8d1e3b795743314b1b06a31a48cfe795ace4R62-R69), [link](https://github.com/14A-A-Lyedlik-Devs/Gump/pull/495/files?diff=unified&w=0#diff-51c2edcfdddf30bd8958554fb52c8d1e3b795743314b1b06a31a48cfe795ace4R86-R87))


